### PR TITLE
heap settings as env variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,12 @@ MAINTAINER info@evolveum.com
 
 ENV MP_VERSION 3.7.1
 ENV MP_DIR /opt/midpoint
+ENV XMX 2048M
+ENV XMS 2048M
 
 RUN mkdir -p ${MP_DIR}/var \
  && wget https://evolveum.com/downloads/midpoint/${MP_VERSION}/midpoint-${MP_VERSION}-dist.tar.gz -P ${MP_DIR} \
  && echo 'Extracting midPoint archive...' \
  && tar xzf ${MP_DIR}/midpoint-${MP_VERSION}-dist.tar.gz -C ${MP_DIR} --strip-components=1
 
-CMD ["/bin/sh", "-c", "java -Xmx2048M -Xms2048M -Dfile.encoding=UTF8 -Dmidpoint.home=$MP_DIR/var -jar $MP_DIR/lib/midpoint.war"]
+CMD ["/bin/sh", "-c", "java -Xmx$XMX -Xms$XMS -Dfile.encoding=UTF8 -Dmidpoint.home=$MP_DIR/var -jar $MP_DIR/lib/midpoint.war"]

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ docker pull evolveum/midpoint
 - run on port 8080:
 ```
 docker run -p 8080:8080 --name midpoint evolveum/midpoint
-
+```
 - run on port 8080 with increased heap size:
-
+```
 docker run -p 8080:8080 -e XMX='4096M' XMS='4096M' --name bigger_midpoint evolveum/midpoint
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ docker pull evolveum/midpoint
 - run on port 8080:
 ```
 docker run -p 8080:8080 --name midpoint evolveum/midpoint
+
+- run on port 8080 with increased heap size:
+
+docker run -p 8080:8080 -e XMX='4096M' XMS='4096M' --name bigger_midpoint evolveum/midpoint
 ```
 
 ## Access MidPoint:


### PR DESCRIPTION
Not at all sure it's a good idea, but we're thinking we want to run with a 4GB heap.  Seems like it might be the sort of thing that should be paramaterized so it can be declared at run time rather than be part of the build.