### PR TITLE
Fix docker run with increased heap size.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ docker run -p 8080:8080 --name midpoint evolveum/midpoint
 ```
 - run on port 8080 with increased heap size:
 ```
-docker run -p 8080:8080 -e XMX='4096M' XMS='4096M' --name bigger_midpoint evolveum/midpoint
+docker run -p 8080:8080 -e XMX='4096M' -e XMS='4096M' --name bigger_midpoint evolveum/midpoint
 ```
 
 ## Access MidPoint:


### PR DESCRIPTION
The `docker run` command needs a `-e` for each environmental variable.