### PR TITLE
Propose a docker-compose simplified approach without init container.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,73 +1,45 @@
-version: "3.3"
-
 services:
-  midpoint_data:
-    image: postgres:16-alpine
-    environment:
-     - POSTGRES_PASSWORD=db.secret.pw.007
-     - POSTGRES_USER=midpoint
-     - POSTGRES_INITDB_ARGS=--lc-collate=en_US.utf8 --lc-ctype=en_US.utf8
-    networks:
-     - net
-    volumes:
-     - midpoint_data:/var/lib/postgresql/data
+    postgres:
+        image: postgres:16-alpine
+        environment:
+            - POSTGRES_PASSWORD=db.secret.pw.007
+            - POSTGRES_USER=midpoint
+            - POSTGRES_INITDB_ARGS=--lc-collate=en_US.utf8 --lc-ctype=en_US.utf8
+        volumes:
+            - postgres_data:/var/lib/postgresql/data
 
-  data_init:
-    image: evolveum/midpoint:${MP_VER:-latest}-alpine
-    command: >
-      bash -c "
-      cd /opt/midpoint ;
-      bin/midpoint.sh init-native ;
-      echo ' - - - - - - ' ;
-      bin/ninja.sh -B info >/dev/null 2>/tmp/ninja.log ;
-      grep -q \"ERROR\" /tmp/ninja.log && (
-      bin/ninja.sh run-sql --create --mode REPOSITORY  ;
-      bin/ninja.sh run-sql --create --mode AUDIT
-      ) ||
-      echo -e '\\n Repository init is not needed...' ;
-      "
-    depends_on:
-     - midpoint_data
-    environment:
-     - MP_SET_midpoint_repository_jdbcUsername=midpoint
-     - MP_SET_midpoint_repository_jdbcPassword=db.secret.pw.007
-     - MP_SET_midpoint_repository_jdbcUrl=jdbc:postgresql://midpoint_data:5432/midpoint
-     - MP_SET_midpoint_repository_database=postgresql
-     - MP_INIT_CFG=/opt/midpoint/var
-    networks:
-     - net
-    volumes:
-     - midpoint_home:/opt/midpoint/var
-
-  midpoint_server:
-    image: evolveum/midpoint:${MP_VER:-latest}-alpine
-    container_name: midpoint_server
-    hostname: midpoint-container
-    depends_on:
-      data_init:
-        condition: service_completed_successfully
-      midpoint_data:
-        condition: service_started
-    command: [ "/opt/midpoint/bin/midpoint.sh", "container" ]
-    ports:
-      - 8080:8080
-    environment:
-     - MP_SET_midpoint_repository_jdbcUsername=midpoint
-     - MP_SET_midpoint_repository_jdbcPassword=db.secret.pw.007
-     - MP_SET_midpoint_repository_jdbcUrl=jdbc:postgresql://midpoint_data:5432/midpoint
-     - MP_SET_midpoint_repository_database=postgresql
-     - MP_SET_midpoint_administrator_initialPassword=Test5ecr3t
-     - MP_UNSET_midpoint_repository_hibernateHbm2ddl=1
-     - MP_NO_ENV_COMPAT=1
-    networks:
-     - net
-    volumes:
-     - midpoint_home:/opt/midpoint/var
-
-networks:
-  net:
-    driver: bridge
+    midpoint:
+        image: evolveum/midpoint:4.8.3-alpine
+        depends_on:
+            postgres:
+                condition: service_started
+        command: >
+            bash -c "
+            cd /opt/midpoint ;
+            bin/midpoint.sh init-native ;
+            echo ' - - - - - - ' ;
+            bin/ninja.sh -B info >/dev/null 2>/tmp/ninja.log ;
+            grep -q \"ERROR\" /tmp/ninja.log && (
+            bin/ninja.sh run-sql --create --mode REPOSITORY  ;
+            bin/ninja.sh run-sql --create --mode AUDIT
+            ) ||
+            echo -e '\\n Repository init is not needed...' ;
+            /opt/midpoint/bin/midpoint.sh container ;
+            "
+        ports:
+            - 8080:8080
+        environment:
+            - MP_SET_midpoint_repository_jdbcUsername=midpoint
+            - MP_SET_midpoint_repository_jdbcPassword=db.secret.pw.007
+            - MP_SET_midpoint_repository_jdbcUrl=jdbc:postgresql://postgres:5432/midpoint
+            - MP_SET_midpoint_repository_database=postgresql
+            - MP_SET_midpoint_administrator_initialPassword=5ecR3t4ever
+            - MP_UNSET_midpoint_repository_hibernateHbm2ddl=1
+            - MP_NO_ENV_COMPAT=1
+            - MP_INIT_CFG=/opt/midpoint/var
+        volumes:
+            - midpoint_home:/opt/midpoint/var
 
 volumes:
-  midpoint_data:
-  midpoint_home:
+    postgres_data:
+    midpoint_home:


### PR DESCRIPTION
The current base setup for Midpoint native on docker is using a dedicated container for initialization of the database. This init container requires to be based on the same base image as the midpoint server itself. Both midpoint and init use a custom command for container initialization and we have to duplicate DB environment variables.

I think it would be preferable to avoid this by having midpoint run the initialization scripts before startup. I would even suggest if you could maintain a set of docker images that would have this initialization hardcoded on tags like 4.8.3-native-alpine for instance ? This way we could bootstrap images in Docker compose or Kubernetes cluster much more conveniently.